### PR TITLE
[GW-2] - Rota /works não ordena por mais contratados

### DIFF
--- a/app/Http/Controllers/Work/ListWorksController.php
+++ b/app/Http/Controllers/Work/ListWorksController.php
@@ -21,6 +21,7 @@ class ListWorksController extends Controller
     {
         $page = $request->get('page', 1);
         $filters = $request->all(['search', 'stars', 'specialties', 'city']);
+        $filters['moreHires'] = true;
         if (! empty($filters['specialties'])) {
             $filters['specialties'] = explode(',', $filters['specialties']);
         }


### PR DESCRIPTION
Listagem de trabalhos na rota "/works" ordenada de forma semelhante ao Landingpage "/".